### PR TITLE
Publish to pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,20 @@ pip install kalgory
 from kalgory.component import BaseBlock
 
 class Block(BaseBlock):
-    def handle(self, **kwargs) -> bytes:
+    def handle(self, *args) -> bytes:
         # You can write any data handling logic here as you want
         pass
 ```
+for example
+```python
+from kalgory.component import BaseBlock
+
+class Block(BaseBlock):
+    def handle(self, NVDA_stock_price: float, money_in_the_bank: float) -> bool:
+        buy = True if NVDA_stock_price > NVDA_future_price else False
+        return buy
+```
+
 
 ## Contributing
 

--- a/kalgory/bindings/block/__init__.py
+++ b/kalgory/bindings/block/__init__.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 from typing import TypeVar, Generic, Union, Optional, Protocol, Tuple, List, Any
 from enum import Flag, Enum, auto
 from dataclasses import dataclass

--- a/kalgory/bindings/block/types.py
+++ b/kalgory/bindings/block/types.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 from typing import TypeVar, Generic, Union, Optional, Protocol, Tuple, List, Any
 from enum import Flag, Enum, auto
 from dataclasses import dataclass

--- a/kalgory/component/block.py
+++ b/kalgory/component/block.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import json
 from abc import ABC
 

--- a/kalgory/component/utility.py
+++ b/kalgory/component/utility.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import json
 from typing import get_type_hints
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+[project]
+name = "kalgory"
+version = "0.0.1"
+authors = [
+  { name="Kalgory-com", email="chuweichang0319@gmail.com" },
+]
+description = "Python library for kalgory, a visualization and drag n' drop tool for algorithmic trader."
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    "Operating System :: MacOS",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft",
+    "Operating System :: Microsoft :: Windows",
+]
+[tool.hatch.build.targets.wheel]
+packages = ["kalgory-py/kalgory"]
+include = ["kalgory-py/kalgory/**"]
+
+
+[project.urls]
+Homepage = "https://github.com/kalgory-com/kalgory-py"
+Issues = "https://github.com/kalgory-com/kalgory-py/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 [project]
 name = "kalgory"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
-  { name="Kalgory-com", email="chuweichang0319@gmail.com" },
+  { name="Chu Wei Chang", email="chuweichang0319@gmail.com" },
+  { name="ZhaoTzuHsien", email="danny900714@gmail.com" }
 ]
 description = "Python library for kalgory, a visualization and drag n' drop tool for algorithmic trader."
 readme = "README.md"

--- a/tests/test_kalgory.py
+++ b/tests/test_kalgory.py
@@ -1,3 +1,17 @@
+# Copyright (c) Fermyon Technologies. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import subprocess
 

--- a/tests/test_kalgory.py
+++ b/tests/test_kalgory.py
@@ -1,3 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# ----
+
 # Copyright (c) Fermyon Technologies. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +17,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 import json
 import subprocess

--- a/wit/block.wit
+++ b/wit/block.wit
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package kalgory:component@0.1.0;
 
 world block {


### PR DESCRIPTION
#4 #8 
I just published the library onto [pypitest](https://test.pypi.org/project/kalgory/).
The email part currently leads to mine, since I lost track of our collective email account on Cloudflare. This is just a publishing test, and official publish will be made after the email section is set correctly and this PR is approved.